### PR TITLE
Set a timeout on GitHub API calls

### DIFF
--- a/script/github_bot/github_bot.py
+++ b/script/github_bot/github_bot.py
@@ -77,6 +77,7 @@ def get_data(page=1):
     args = '?page={page}'.format(page=page)
 
     response = requests.get(API['events']+args,
+                                timeout=10.0,
                             auth=(ACCOUNT['username'], ACCOUNT['password']))
     status_code = response.status_code
     if status_code == 200:


### PR DESCRIPTION
During an automated code review of script/github_bot/github_bot.py, the following issue was identified. Set a timeout on GitHub API calls. Network calls without a timeout can hang a worker indefinitely. I kept the patch small and re-ran syntax checks after applying it.