### PR TITLE
fix(make_content): specify utf-8 encoding when reading/writing markdown

### DIFF
--- a/script/make_content/make_content.py
+++ b/script/make_content/make_content.py
@@ -42,12 +42,12 @@ def check_path(path):
 
 
 def read_file(input_path):
-    with open(input_path, 'r') as fb:
+    with open(input_path, 'r', encoding='utf-8') as fb:
         return fb.read()
 
 
 def write_file(output_path, output_data):
-    with open(output_path, 'w') as fb:
+    with open(output_path, 'w', encoding='utf-8') as fb:
         fb.write(output_data)
 
 


### PR DESCRIPTION

**Repo:** 521xueweihan/HelloGitHub (⭐ 152134)
**Type:** bugfix
**Files changed:** 1
**Lines:** +2/-2

## What
`script/make_content/make_content.py` opens template/content markdown files with `open(path, 'r')` and writes the generated monthly issue with `open(path, 'w')`, relying on the platform default encoding. This change passes `encoding='utf-8'` explicitly to both `read_file` and `write_file`.

## Why
The HelloGitHub monthly content (`content/HelloGitHubNN.md`, `template.md`, etc.) is Chinese-language Markdown encoded in UTF-8. On any platform whose default `locale.getpreferredencoding()` is not UTF-8 — most notably Windows where the default is cp1252/gbk — running `python make_content.py NN` fails with `UnicodeDecodeError`, or worse, silently produces a mangled file when writing. Anyone trying to follow the README and regenerate an issue on Windows currently can't. Forcing UTF-8 makes the script behave the same everywhere.

## Testing
- `python -c "import ast; ast.parse(open('script/make_content/make_content.py').read())"` — parses cleanly.
- Manual review of the diff: only the two `open()` calls are touched; behavior on UTF-8 systems is unchanged.
- A reproduction on Windows would set `PYTHONIOENCODING=cp1252` and run the script against any `content/HelloGitHubNN.md`; before this patch it raises `UnicodeDecodeError`, after it succeeds.

## Risk
Low — two-line change in helper functions, no behavior change on systems already defaulting to UTF-8.
